### PR TITLE
Fix analyzer reference for central package management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <!-- Common analyzers (optional, light) -->
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- remove the explicit version from the analyzer PackageReference so it respects central package management

## Testing
- not run (CI)


------
https://chatgpt.com/codex/tasks/task_e_68d7b49f79b4832fb35aa91d36b280f9