### PR TITLE
Ensure local NuGet feed directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@ logs/
 Thumbs.db
 
 # Tools
-.nuget/
+.nuget/*
+!.nuget/feed/
+!.nuget/feed/README.md
 .nuke/

--- a/.nuget/feed/README.md
+++ b/.nuget/feed/README.md
@@ -1,0 +1,1 @@
+This directory holds locally packed NuGet packages for MicroShop.


### PR DESCRIPTION
## Summary
- create the missing .nuget/feed directory with a README placeholder so the local feed exists
- adjust the .gitignore to keep the feed directory in source control while still ignoring other local artifacts

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7b57a4624832fa7afb19acdb63acf