### PR TITLE
Fix NUlid package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
     <!-- Building blocks deps -->
-    <PackageVersion Include="NUlid" Version="2.0.1" />
+    <PackageVersion Include="NUlid" Version="1.7.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
     <!-- Tests -->


### PR DESCRIPTION
## Summary
- correct the central package version for NUlid to use the latest available release on NuGet

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68d7b673b38c832fba329b5ac563d795