### PR TITLE
Enable documentation generation for contracts project

### DIFF
--- a/src/BuildingBlocks/Contracts/MicroShop.BuildingBlocks.Contracts.csproj
+++ b/src/BuildingBlocks/Contracts/MicroShop.BuildingBlocks.Contracts.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>true</WarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- NuGetization -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
## Summary
- set GenerateDocumentationFile to true for the contracts project to satisfy analyzer requirements

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b7403f60832fa8bf872caef7d0af