### PR TITLE
Remove redundant usings from messaging contracts

### DIFF
--- a/src/BuildingBlocks/Contracts/Messaging/MessageMetadata.cs
+++ b/src/BuildingBlocks/Contracts/Messaging/MessageMetadata.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace MicroShop.BuildingBlocks.Contracts.Messaging
 {
   /// <summary>

--- a/src/BuildingBlocks/Contracts/Messaging/Sample/Catalog.ProductPriceChanged.V1.cs
+++ b/src/BuildingBlocks/Contracts/Messaging/Sample/Catalog.ProductPriceChanged.V1.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace MicroShop.BuildingBlocks.Contracts.Messaging.Sample
 {
   /// <summary>


### PR DESCRIPTION
## Summary
- remove redundant using directives from messaging contract record definitions
- rely on project-wide implicit usings to satisfy analyzer IDE0005 and unblock builds

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b90eb120832fa3d1fc7f887f5cc5