### PR TITLE
Enable documentation generation and update analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <!-- Infra tooling -->
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <!-- Building blocks deps -->
     <PackageVersion Include="NUlid" Version="1.7.3" />
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />

--- a/src/BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj
+++ b/src/BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>true</WarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- NuGetization -->
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
## Summary
- enable XML documentation output for the abstractions project to allow analyzer enforcement during builds
- align Microsoft.CodeAnalysis.NetAnalyzers package with the SDK-provided 9.0.0 analyzers

## Testing
- not run (dotnet CLI is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7beba8740832fa8538b014a770cc4