### PR TITLE
Add XML documentation to public abstractions

### DIFF
--- a/src/BuildingBlocks/Abstractions/Common/Error.cs
+++ b/src/BuildingBlocks/Abstractions/Common/Error.cs
@@ -1,8 +1,21 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Common
 {
+  /// <summary>
+  /// Represents an application level error with a code and message.
+  /// </summary>
+  /// <param name="Code">The machine readable identifier of the error.</param>
+  /// <param name="Message">The human readable description of the error.</param>
   public sealed record Error(string Code, string Message)
   {
+    /// <summary>
+    /// Gets an <see cref="Error"/> instance representing the absence of an error.
+    /// </summary>
     public static Error None => new("", "");
+
+    /// <summary>
+    /// Returns a string that represents the current error.
+    /// </summary>
+    /// <returns>A string containing the error code and message.</returns>
     public override string ToString()
     {
       return $"{this.Code}: {this.Message}";

--- a/src/BuildingBlocks/Abstractions/Common/Pagination.cs
+++ b/src/BuildingBlocks/Abstractions/Common/Pagination.cs
@@ -1,9 +1,25 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Common
 {
+  /// <summary>
+  /// Describes pagination options for a resource collection.
+  /// </summary>
+  /// <param name="Page">The requested page number (1-based).</param>
+  /// <param name="Size">The number of items requested per page.</param>
   public sealed record PageRequest(int Page, int Size)
   {
+    /// <summary>
+    /// Gets the number of items to skip when applying the pagination options.
+    /// </summary>
     public int Skip => this.Page < 1 ? 0 : (this.Page - 1) * this.Size;
   }
 
+  /// <summary>
+  /// Represents a paginated response that includes items and paging metadata.
+  /// </summary>
+  /// <typeparam name="T">The type of the item contained in the page.</typeparam>
+  /// <param name="Items">The items returned for the current page.</param>
+  /// <param name="Page">The current page number (1-based).</param>
+  /// <param name="Size">The size of the page.</param>
+  /// <param name="TotalCount">The total number of available items.</param>
   public sealed record PagedResult<T>(IReadOnlyList<T> Items, int Page, int Size, long TotalCount);
 }

--- a/src/BuildingBlocks/Abstractions/Common/Result.cs
+++ b/src/BuildingBlocks/Abstractions/Common/Result.cs
@@ -1,41 +1,90 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Common
 {
+  /// <summary>
+  /// Represents the outcome of an operation that does not produce a value.
+  /// </summary>
   public class Result
   {
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
     public bool IsSuccess { get; }
+
+    /// <summary>
+    /// Gets the error associated with the operation when it fails.
+    /// </summary>
     public Error Error { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Result"/> class.
+    /// </summary>
+    /// <param name="isSuccess">True if the operation was successful.</param>
+    /// <param name="error">The error describing the failure.</param>
     protected Result(bool isSuccess, Error error)
     {
       this.IsSuccess = isSuccess;
       this.Error = error;
     }
 
+    /// <summary>
+    /// Creates a successful <see cref="Result"/> instance.
+    /// </summary>
+    /// <returns>A successful result.</returns>
     public static Result Ok()
     {
       return new(true, Error.None);
     }
 
+    /// <summary>
+    /// Creates a failed <see cref="Result"/> instance.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <param name="message">The error message.</param>
+    /// <returns>A failed result.</returns>
     public static Result Fail(string code, string message)
     {
       return new(false, new Error(code, message));
     }
   }
 
+  /// <summary>
+  /// Represents the outcome of an operation that produces a value.
+  /// </summary>
+  /// <typeparam name="T">The type of value produced by the operation.</typeparam>
   public sealed class Result<T> : Result
   {
+    /// <summary>
+    /// Gets the value produced by the operation when it succeeds.
+    /// </summary>
     public T? Value { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Result{T}"/> class.
+    /// </summary>
+    /// <param name="isSuccess">True if the operation was successful.</param>
+    /// <param name="value">The result value.</param>
+    /// <param name="error">The error describing the failure.</param>
     private Result(bool isSuccess, T? value, Error error) : base(isSuccess, error)
     {
       this.Value = value;
     }
 
+    /// <summary>
+    /// Creates a successful <see cref="Result{T}"/> instance containing the specified value.
+    /// </summary>
+    /// <param name="value">The value produced by the operation.</param>
+    /// <returns>A successful result containing <paramref name="value"/>.</returns>
     public static Result<T> Ok(T value)
     {
       return new(true, value, Error.None);
     }
 
+    /// <summary>
+    /// Creates a failed <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <param name="message">The error message.</param>
+    /// <returns>A failed result.</returns>
     public static new Result<T> Fail(string code, string message)
     {
       return new(false, default, new Error(code, message));

--- a/src/BuildingBlocks/Abstractions/Correlation/CorrelationIds.cs
+++ b/src/BuildingBlocks/Abstractions/Correlation/CorrelationIds.cs
@@ -1,4 +1,9 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Correlation
 {
+  /// <summary>
+  /// Encapsulates correlation identifiers propagated between services.
+  /// </summary>
+  /// <param name="CorrelationId">The identifier that links related operations.</param>
+  /// <param name="CausationId">The identifier for the operation that triggered the current action.</param>
   public sealed record CorrelationIds(string? CorrelationId, string? CausationId);
 }

--- a/src/BuildingBlocks/Abstractions/Correlation/CorrelationMiddleware.cs
+++ b/src/BuildingBlocks/Abstractions/Correlation/CorrelationMiddleware.cs
@@ -4,21 +4,47 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace MicroShop.BuildingBlocks.Abstractions.Correlation
 {
+  /// <summary>
+  /// Provides access to the current <see cref="CorrelationIds"/> for the active request.
+  /// </summary>
   public sealed class CorrelationContextAccessor : ICorrelationContextAccessor
   {
+    /// <summary>
+    /// Gets or sets the current correlation context.
+    /// </summary>
     public CorrelationIds Current { get; set; } = new(null, null);
   }
 
+  /// <summary>
+  /// Extension methods for registering and using correlation context services.
+  /// </summary>
   public static class CorrelationExtensions
   {
+    /// <summary>
+    /// The HTTP header used to transport the correlation identifier.
+    /// </summary>
     public const string CorrelationHeader = "x-correlation-id";
+
+    /// <summary>
+    /// The HTTP header used to transport the causation identifier.
+    /// </summary>
     public const string CausationHeader = "x-causation-id";
 
+    /// <summary>
+    /// Registers the correlation context accessor in the service collection.
+    /// </summary>
+    /// <param name="services">The application service collection.</param>
+    /// <returns>The original service collection for chaining.</returns>
     public static IServiceCollection AddCorrelationContext(this IServiceCollection services)
     {
       return services.AddSingleton<ICorrelationContextAccessor, CorrelationContextAccessor>();
     }
 
+    /// <summary>
+    /// Adds middleware that ensures correlation identifiers are available for requests.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <returns>The original application builder for chaining.</returns>
     public static IApplicationBuilder UseCorrelationContext(this IApplicationBuilder app)
     {
       return app.Use(async (ctx, next) =>

--- a/src/BuildingBlocks/Abstractions/Correlation/ICorrelationContextAccessor.cs
+++ b/src/BuildingBlocks/Abstractions/Correlation/ICorrelationContextAccessor.cs
@@ -1,7 +1,13 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Correlation
 {
+  /// <summary>
+  /// Provides access to the correlation context for the current execution flow.
+  /// </summary>
   public interface ICorrelationContextAccessor
   {
+    /// <summary>
+    /// Gets or sets the active correlation identifiers.
+    /// </summary>
     CorrelationIds Current { get; set; }
   }
 }

--- a/src/BuildingBlocks/Abstractions/IdGeneration/IIdGenerator.cs
+++ b/src/BuildingBlocks/Abstractions/IdGeneration/IIdGenerator.cs
@@ -1,7 +1,14 @@
 namespace MicroShop.BuildingBlocks.Abstractions.IdGeneration
 {
+  /// <summary>
+  /// Provides a mechanism for generating unique identifiers.
+  /// </summary>
   public interface IIdGenerator
   {
+    /// <summary>
+    /// Creates a new unique identifier.
+    /// </summary>
+    /// <returns>A new identifier string.</returns>
     string NewId();
   }
 }

--- a/src/BuildingBlocks/Abstractions/IdGeneration/UlidIdGenerator.cs
+++ b/src/BuildingBlocks/Abstractions/IdGeneration/UlidIdGenerator.cs
@@ -2,8 +2,12 @@ using NUlid;
 
 namespace MicroShop.BuildingBlocks.Abstractions.IdGeneration
 {
+  /// <summary>
+  /// Generates ULID based unique identifiers.
+  /// </summary>
   public sealed class UlidIdGenerator : IIdGenerator
   {
+    /// <inheritdoc />
     public string NewId()
     {
       return Ulid.NewUlid().ToString();

--- a/src/BuildingBlocks/Abstractions/Messaging/IEventBus.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/IEventBus.cs
@@ -2,11 +2,26 @@ using MicroShop.BuildingBlocks.Contracts.Messaging;
 
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Defines operations for publishing integration events and commands.
+  /// </summary>
   public interface IEventBus
   {
+    /// <summary>
+    /// Publishes an integration event to interested subscribers.
+    /// </summary>
+    /// <typeparam name="TEvent">The event payload type.</typeparam>
+    /// <param name="envelope">The envelope containing the event and metadata.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task PublishAsync<TEvent>(MessageEnvelope<TEvent> envelope, CancellationToken ct = default)
           where TEvent : IIntegrationEvent;
 
+    /// <summary>
+    /// Sends an integration command to a single consumer.
+    /// </summary>
+    /// <typeparam name="TCommand">The command payload type.</typeparam>
+    /// <param name="envelope">The envelope containing the command and metadata.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task SendAsync<TCommand>(MessageEnvelope<TCommand> envelope, CancellationToken ct = default)
           where TCommand : IIntegrationCommand;
   }

--- a/src/BuildingBlocks/Abstractions/Messaging/IMessageSerializer.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/IMessageSerializer.cs
@@ -1,9 +1,29 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Provides serialization services for messaging payloads.
+  /// </summary>
   public interface IMessageSerializer
   {
+    /// <summary>
+    /// Gets the content type produced by the serializer.
+    /// </summary>
     string ContentType { get; }
+
+    /// <summary>
+    /// Serializes the provided value to a string representation.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to serialize.</typeparam>
+    /// <param name="value">The value to serialize.</param>
+    /// <returns>The serialized payload.</returns>
     string Serialize<T>(T value);
+
+    /// <summary>
+    /// Deserializes the provided payload to the specified type.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="payload">The serialized payload.</param>
+    /// <returns>The deserialized value.</returns>
     T Deserialize<T>(string payload);
   }
 }

--- a/src/BuildingBlocks/Abstractions/Messaging/Idempotency.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/Idempotency.cs
@@ -1,8 +1,24 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Defines storage operations required to enforce message idempotency.
+  /// </summary>
   public interface IIdempotencyStore
   {
+    /// <summary>
+    /// Attempts to begin processing for the specified message key.
+    /// </summary>
+    /// <param name="key">The unique message identifier.</param>
+    /// <param name="ttl">The time the reservation remains valid.</param>
+    /// <param name="ct">A token to observe while waiting for the task to complete.</param>
+    /// <returns><c>true</c> if the message can be processed; otherwise <c>false</c>.</returns>
     Task<bool> TryBeginAsync(string key, TimeSpan ttl, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the specified message key as completed.
+    /// </summary>
+    /// <param name="key">The unique message identifier.</param>
+    /// <param name="ct">A token to observe while waiting for the task to complete.</param>
     Task EndAsync(string key, CancellationToken ct = default);
   }
 }

--- a/src/BuildingBlocks/Abstractions/Messaging/Inbox.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/Inbox.cs
@@ -1,15 +1,43 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Represents a message tracked by the inbox pattern.
+  /// </summary>
+  /// <param name="Id">The unique message identifier.</param>
+  /// <param name="MessageType">The CLR type name of the message.</param>
+  /// <param name="ReceivedOnUtc">The UTC timestamp when the message was received.</param>
+  /// <param name="ProcessedOnUtc">The UTC timestamp when the message was processed.</param>
   public sealed record InboxMessage(
       string Id,
       string MessageType,
       DateTimeOffset ReceivedOnUtc,
       DateTimeOffset? ProcessedOnUtc = null);
 
+  /// <summary>
+  /// Defines persistence operations for inbox messages.
+  /// </summary>
   public interface IInboxStore
   {
+    /// <summary>
+    /// Determines whether a message with the provided identifier already exists.
+    /// </summary>
+    /// <param name="id">The message identifier.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns><c>true</c> if the message exists; otherwise <c>false</c>.</returns>
     Task<bool> ExistsAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Stores the provided inbox message.
+    /// </summary>
+    /// <param name="message">The inbox message to store.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task AddAsync(InboxMessage message, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the specified message as processed.
+    /// </summary>
+    /// <param name="id">The message identifier.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task MarkProcessedAsync(string id, CancellationToken ct = default);
   }
 }

--- a/src/BuildingBlocks/Abstractions/Messaging/MessageEnvelope.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/MessageEnvelope.cs
@@ -2,6 +2,12 @@ using MicroShop.BuildingBlocks.Contracts.Messaging;
 
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Wraps a message together with metadata for transport.
+  /// </summary>
+  /// <typeparam name="T">The message payload type.</typeparam>
+  /// <param name="Message">The message payload.</param>
+  /// <param name="Metadata">The metadata describing the message.</param>
   public sealed record MessageEnvelope<T>(
       T Message,
       MessageMetadata Metadata);

--- a/src/BuildingBlocks/Abstractions/Messaging/Outbox.cs
+++ b/src/BuildingBlocks/Abstractions/Messaging/Outbox.cs
@@ -1,5 +1,17 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Messaging
 {
+  /// <summary>
+  /// Represents a message persisted as part of the outbox pattern.
+  /// </summary>
+  /// <param name="Id">The unique message identifier.</param>
+  /// <param name="MessageType">The CLR type name of the message.</param>
+  /// <param name="Content">The serialized message payload.</param>
+  /// <param name="OccurredOnUtc">The UTC timestamp when the message occurred.</param>
+  /// <param name="CorrelationId">The correlation identifier associated with the message.</param>
+  /// <param name="CausationId">The causation identifier associated with the message.</param>
+  /// <param name="Version">The schema version of the message.</param>
+  /// <param name="ProcessedOnUtc">The UTC timestamp when the message was processed.</param>
+  /// <param name="Error">The error message captured when message processing fails.</param>
   public sealed record OutboxMessage(
       string Id,
       string MessageType,
@@ -11,11 +23,39 @@ namespace MicroShop.BuildingBlocks.Abstractions.Messaging
       DateTimeOffset? ProcessedOnUtc = null,
       string? Error = null);
 
+  /// <summary>
+  /// Defines persistence operations for the outbox pattern.
+  /// </summary>
   public interface IOutboxStore
   {
+    /// <summary>
+    /// Adds a new outbox message to the store.
+    /// </summary>
+    /// <param name="message">The message to add.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task AddAsync(OutboxMessage message, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves unprocessed messages from the store.
+    /// </summary>
+    /// <param name="take">The maximum number of messages to retrieve.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>A read-only list of unprocessed messages.</returns>
     Task<IReadOnlyList<OutboxMessage>> GetUnprocessedAsync(int take = 100, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the message with the provided identifier as processed.
+    /// </summary>
+    /// <param name="id">The message identifier.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task MarkProcessedAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the message with the provided identifier as failed.
+    /// </summary>
+    /// <param name="id">The message identifier.</param>
+    /// <param name="error">The error encountered during processing.</param>
+    /// <param name="ct">A cancellation token.</param>
     Task MarkFailedAsync(string id, string error, CancellationToken ct = default);
   }
 }

--- a/src/BuildingBlocks/Abstractions/Persistence/IUnitOfWork.cs
+++ b/src/BuildingBlocks/Abstractions/Persistence/IUnitOfWork.cs
@@ -1,7 +1,15 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Persistence
 {
+  /// <summary>
+  /// Coordinates transactional persistence operations.
+  /// </summary>
   public interface IUnitOfWork
   {
+    /// <summary>
+    /// Persists pending changes to the underlying data store.
+    /// </summary>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>The number of affected entries.</returns>
     Task<int> SaveChangesAsync(CancellationToken ct = default);
   }
 }

--- a/src/BuildingBlocks/Abstractions/Telemetry/Tracing.cs
+++ b/src/BuildingBlocks/Abstractions/Telemetry/Tracing.cs
@@ -2,9 +2,21 @@ using System.Diagnostics;
 
 namespace MicroShop.BuildingBlocks.Abstractions.Telemetry
 {
+  /// <summary>
+  /// Provides helpers for emitting tracing information.
+  /// </summary>
   public static class Tracing
   {
+    /// <summary>
+    /// The shared activity source used by the application.
+    /// </summary>
     public static readonly ActivitySource Source = new("MicroShop");
+
+    /// <summary>
+    /// Starts a new activity with the provided name.
+    /// </summary>
+    /// <param name="name">The activity name.</param>
+    /// <returns>The started <see cref="Activity"/>, or <c>null</c> if tracing is disabled.</returns>
     public static Activity? StartActivity(string name)
     {
       return Source.StartActivity(name, ActivityKind.Internal);

--- a/src/BuildingBlocks/Abstractions/Time/IClock.cs
+++ b/src/BuildingBlocks/Abstractions/Time/IClock.cs
@@ -1,7 +1,13 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Time
 {
+  /// <summary>
+  /// Abstraction for retrieving the current time.
+  /// </summary>
   public interface IClock
   {
+    /// <summary>
+    /// Gets the current UTC timestamp.
+    /// </summary>
     DateTimeOffset UtcNow { get; }
   }
 }

--- a/src/BuildingBlocks/Abstractions/Time/SystemClock.cs
+++ b/src/BuildingBlocks/Abstractions/Time/SystemClock.cs
@@ -1,7 +1,11 @@
 namespace MicroShop.BuildingBlocks.Abstractions.Time
 {
+  /// <summary>
+  /// Provides the system implementation of <see cref="IClock"/>.
+  /// </summary>
   public sealed class SystemClock : IClock
   {
+    /// <inheritdoc />
     public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
   }
 }


### PR DESCRIPTION
## Summary
- add XML documentation comments across the BuildingBlocks abstractions
- describe error handling, pagination, messaging, persistence, telemetry, and time contracts for clarity and tooling support

## Testing
- dotnet build *(fails: .NET SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c421c878832fa59adf2d61e8f575