### PR TITLE
Enable documentation generation in test and sample projects

### DIFF
--- a/samples/Dummy/Dummy.API/MicroShop.Services.Dummy.API.csproj
+++ b/samples/Dummy/Dummy.API/MicroShop.Services.Dummy.API.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>true</WarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../../../src/BuildingBlocks/Contracts/MicroShop.BuildingBlocks.Contracts.csproj" />

--- a/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
+++ b/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>true</WarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BuildingBlocks\Abstractions\MicroShop.BuildingBlocks.Abstractions.csproj" />


### PR DESCRIPTION
## Summary
- enable XML documentation generation for the BuildingBlocks abstractions tests project
- enable XML documentation generation for the Dummy API sample project

## Testing
- dotnet build *(fails: `dotnet` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c63f213c832fb18016591ab3dcca