### PR TITLE
Add documentation comments to Result tests

### DIFF
--- a/tests/BuildingBlocks.Abstractions.Tests/ResultTests.cs
+++ b/tests/BuildingBlocks.Abstractions.Tests/ResultTests.cs
@@ -2,9 +2,15 @@ using FluentAssertions;
 using MicroShop.BuildingBlocks.Abstractions.Common;
 using Xunit;
 
+/// <summary>
+/// Contains unit tests that validate the <see cref="Result{T}"/> helper type.
+/// </summary>
 public class ResultTests
 {
   [Fact]
+  /// <summary>
+  /// Ensures a successful result exposes the provided value and no error details.
+  /// </summary>
   public void Ok_ShouldCarryValue()
   {
     var r = Result<int>.Ok(42);
@@ -14,6 +20,9 @@ public class ResultTests
   }
 
   [Fact]
+  /// <summary>
+  /// Ensures a failed result exposes the provided error information.
+  /// </summary>
   public void Fail_ShouldCarryError()
   {
     var r = Result<int>.Fail("E.TEST", "failed");


### PR DESCRIPTION
## Summary
- add XML documentation comments to the ResultTests class and its test methods to satisfy documentation requirements

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c76fc0e8832fa397dfddd77609eb