### PR TITLE
Fix XML documentation for result tests

### DIFF
--- a/tests/BuildingBlocks.Abstractions.Tests/ResultTests.cs
+++ b/tests/BuildingBlocks.Abstractions.Tests/ResultTests.cs
@@ -7,10 +7,10 @@ using Xunit;
 /// </summary>
 public class ResultTests
 {
-  [Fact]
   /// <summary>
   /// Ensures a successful result exposes the provided value and no error details.
   /// </summary>
+  [Fact]
   public void Ok_ShouldCarryValue()
   {
     var r = Result<int>.Ok(42);
@@ -19,10 +19,10 @@ public class ResultTests
     _ = r.Error.Should().Be(Error.None);
   }
 
-  [Fact]
   /// <summary>
   /// Ensures a failed result exposes the provided error information.
   /// </summary>
+  [Fact]
   public void Fail_ShouldCarryError()
   {
     var r = Result<int>.Fail("E.TEST", "failed");


### PR DESCRIPTION
## Summary
- move the XML documentation comments in `ResultTests` above the associated test attributes so they apply to the correct members

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7c8946e98832f99862a511ff71b11