### PR TITLE
Ensure test dependencies are copied to the output

### DIFF
--- a/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
+++ b/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>true</WarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BuildingBlocks\Abstractions\MicroShop.BuildingBlocks.Abstractions.csproj" />


### PR DESCRIPTION
## Summary
- ensure the abstraction tests copy referenced packages into their output folder to avoid missing FluentAssertions assemblies

## Testing
- not run (environment lacks dotnet runtime)

------
https://chatgpt.com/codex/tasks/task_e_68d7c9c19bb4832f84e2ea71c7cf6f6b