### PR TITLE
Add Newtonsoft.Json dependency for test project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
     <!-- Tests -->
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />

--- a/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
+++ b/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BuildingBlocks\Abstractions\MicroShop.BuildingBlocks.Abstractions.csproj" />
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />


### PR DESCRIPTION
## Summary
- add a central package version for Newtonsoft.Json
- reference Newtonsoft.Json from the BuildingBlocks abstractions test project to satisfy runtime dependencies

## Testing
- dotnet test tests/BuildingBlocks.Abstractions.Tests *(fails: dotnet CLI is unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cae0b704832f9c5a89a00138c5a3