### PR TITLE
Add Microsoft.NET.Test.Sdk dependency to test project

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />
     <!-- Tests -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" />

--- a/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
+++ b/tests/BuildingBlocks.Abstractions.Tests/MicroShop.BuildingBlocks.Abstractions.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\BuildingBlocks\Abstractions\MicroShop.BuildingBlocks.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
## Summary
- add Microsoft.NET.Test.Sdk to the BuildingBlocks abstractions test project
- manage the Microsoft.NET.Test.Sdk package version centrally so restores include the required assemblies

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7cbf76738832fa84784804210560c