### PR TITLE
feat: add identity service for auth

### DIFF
--- a/MicroShop.sln
+++ b/MicroShop.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BuildingBlocks", "BuildingBlocks", "{90298CBA-BD6F-3A0A-69D5-97CAD7B05E7E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Services", "Services", "{F02EF42E-8437-4F8F-B5F8-EBB2D9037450}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Identity", "Identity", "{2289007A-F4A7-4B8E-9B36-6BBE286473FA}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contracts", "Contracts", "{6A36946C-4F06-BE70-24E6-0B0F125A7F9F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.BuildingBlocks.Contracts", "src\BuildingBlocks\Contracts\MicroShop.BuildingBlocks.Contracts.csproj", "{8D2723A3-4694-4410-8095-E4136A866A4C}"
@@ -17,6 +21,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.BuildingBlocks.Ab
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Dummy.API", "samples\Dummy\Dummy.API\MicroShop.Services.Dummy.API.csproj", "{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Identity.Domain", "src\Services\Identity\Domain\MicroShop.Services.Identity.Domain.csproj", "{A7D78740-EF04-4683-87B0-2EF542A446CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Identity.Application", "src\Services\Identity\Application\MicroShop.Services.Identity.Application.csproj", "{85BEAC45-7263-4425-9445-B42204554390}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Identity.Infrastructure", "src\Services\Identity\Infrastructure\MicroShop.Services.Identity.Infrastructure.csproj", "{98CB9B99-660A-4B19-81DB-0829E1411FD7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Identity.API", "src\Services\Identity\API\MicroShop.Services.Identity.API.csproj", "{608C70A1-B51B-414B-B2AD-49C605314D3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicroShop.Services.Identity.Tests", "tests\Services.Identity.Tests\MicroShop.Services.Identity.Tests.csproj", "{2176A311-D027-46A0-B710-D5AA3AD75D76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,9 +40,9 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|x64.Build.0 = Debug|Any CPU
 		{8D2723A3-4694-4410-8095-E4136A866A4C}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -63,28 +77,95 @@ Global
 		{B00518C5-E239-4C3C-9FCC-B773421E1E6C}.Release|x64.Build.0 = Release|Any CPU
 		{B00518C5-E239-4C3C-9FCC-B773421E1E6C}.Release|x86.ActiveCfg = Release|Any CPU
 		{B00518C5-E239-4C3C-9FCC-B773421E1E6C}.Release|x86.Build.0 = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x64.Build.0 = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x86.Build.0 = Debug|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x64.ActiveCfg = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x64.Build.0 = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x86.ActiveCfg = Release|Any CPU
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x64.Build.0 = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Debug|x86.Build.0 = Debug|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x64.ActiveCfg = Release|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x64.Build.0 = Release|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x86.ActiveCfg = Release|Any CPU
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6}.Release|x86.Build.0 = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|x64.Build.0 = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Debug|x86.Build.0 = Debug|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|x64.ActiveCfg = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|x64.Build.0 = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|x86.ActiveCfg = Release|Any CPU
+                {A7D78740-EF04-4683-87B0-2EF542A446CB}.Release|x86.Build.0 = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|x64.Build.0 = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Debug|x86.Build.0 = Debug|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|Any CPU.Build.0 = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|x64.ActiveCfg = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|x64.Build.0 = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|x86.ActiveCfg = Release|Any CPU
+                {85BEAC45-7263-4425-9445-B42204554390}.Release|x86.Build.0 = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|x64.Build.0 = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Debug|x86.Build.0 = Debug|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|x64.ActiveCfg = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|x64.Build.0 = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|x86.ActiveCfg = Release|Any CPU
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7}.Release|x86.Build.0 = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|x64.Build.0 = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Debug|x86.Build.0 = Debug|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|x64.ActiveCfg = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|x64.Build.0 = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|x86.ActiveCfg = Release|Any CPU
+                {608C70A1-B51B-414B-B2AD-49C605314D3C}.Release|x86.Build.0 = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|x64.Build.0 = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Debug|x86.Build.0 = Debug|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|x64.ActiveCfg = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|x64.Build.0 = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|x86.ActiveCfg = Release|Any CPU
+                {2176A311-D027-46A0-B710-D5AA3AD75D76}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{90298CBA-BD6F-3A0A-69D5-97CAD7B05E7E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
-		{6A36946C-4F06-BE70-24E6-0B0F125A7F9F} = {90298CBA-BD6F-3A0A-69D5-97CAD7B05E7E}
-		{8D2723A3-4694-4410-8095-E4136A866A4C} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
-		{B5CBECA7-744E-44A3-865E-2201B6A57807} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
-		{B00518C5-E239-4C3C-9FCC-B773421E1E6C} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
-		{FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
-	EndGlobalSection
+                {6A36946C-4F06-BE70-24E6-0B0F125A7F9F} = {90298CBA-BD6F-3A0A-69D5-97CAD7B05E7E}
+                {8D2723A3-4694-4410-8095-E4136A866A4C} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
+                {B5CBECA7-744E-44A3-865E-2201B6A57807} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
+                {B00518C5-E239-4C3C-9FCC-B773421E1E6C} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
+                {FA2ACC5D-3812-4A5D-BBE4-E76619FF9CA6} = {6A36946C-4F06-BE70-24E6-0B0F125A7F9F}
+                {F02EF42E-8437-4F8F-B5F8-EBB2D9037450} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+                {2289007A-F4A7-4B8E-9B36-6BBE286473FA} = {F02EF42E-8437-4F8F-B5F8-EBB2D9037450}
+                {A7D78740-EF04-4683-87B0-2EF542A446CB} = {2289007A-F4A7-4B8E-9B36-6BBE286473FA}
+                {85BEAC45-7263-4425-9445-B42204554390} = {2289007A-F4A7-4B8E-9B36-6BBE286473FA}
+                {98CB9B99-660A-4B19-81DB-0829E1411FD7} = {2289007A-F4A7-4B8E-9B36-6BBE286473FA}
+                {608C70A1-B51B-414B-B2AD-49C605314D3C} = {2289007A-F4A7-4B8E-9B36-6BBE286473FA}
+                {2176A311-D027-46A0-B710-D5AA3AD75D76} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+        EndGlobalSection
 EndGlobal

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -98,6 +98,33 @@ services:
     volumes:
       - seq-data:/data
 
+  identity-api:
+    build:
+      context: ../..
+      dockerfile: src/Services/Identity/API/Dockerfile
+    container_name: microshop-identity-api
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__Identity=Server=sqlserver;Database=MicroShop_Identity;User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;
+      - Jwt__Issuer=MicroShop.Identity
+      - Jwt__Audience=MicroShop
+      - Jwt__PrivateKeyPath=/app/secrets/identity_rsa_private.pem
+      - Jwt__PublicKeyPath=/app/secrets/identity_rsa_public.pem
+      - RabbitMQ__Host=rabbitmq
+      - RabbitMQ__Username=guest
+      - RabbitMQ__Password=guest
+      - DOTNET_ENVIRONMENT=Development
+    ports:
+      - "5001:8080"
+    volumes:
+      - identity-secrets:/app/secrets
+    depends_on:
+      - sqlserver
+      - rabbitmq
+      - otel-collector
+      - seq
+
 volumes:
   mssql-data:
   seq-data:
+  identity-secrets:

--- a/src/Services/Identity/API/Dockerfile
+++ b/src/Services/Identity/API/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.7
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+ENV ASPNETCORE_URLS=http://+:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
+COPY MicroShop.sln ./
+COPY src ./src
+COPY tests ./tests
+RUN dotnet restore MicroShop.sln
+RUN dotnet publish src/Services/Identity/API/MicroShop.Services.Identity.API.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish ./
+ENTRYPOINT ["dotnet", "MicroShop.Services.Identity.API.dll"]

--- a/src/Services/Identity/API/MicroShop.Services.Identity.API.csproj
+++ b/src/Services/Identity/API/MicroShop.Services.Identity.API.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <PackageReference Include="MassTransit.AspNetCore" Version="8.2.3" />
+    <PackageReference Include="MassTransit" Version="8.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj" />
+    <ProjectReference Include="../../../BuildingBlocks/Contracts/MicroShop.BuildingBlocks.Contracts.csproj" />
+    <ProjectReference Include="../Application/MicroShop.Services.Identity.Application.csproj" />
+    <ProjectReference Include="../Domain/MicroShop.Services.Identity.Domain.csproj" />
+    <ProjectReference Include="../Infrastructure/MicroShop.Services.Identity.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Identity/API/Program.cs
+++ b/src/Services/Identity/API/Program.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using MicroShop.BuildingBlocks.Abstractions.Correlation;
+using MicroShop.Services.Identity.Application.Authentication.Commands;
+using MicroShop.Services.Identity.Application.Users.Queries;
+using MicroShop.Services.Identity.Infrastructure.DependencyInjection;
+using MicroShop.Services.Identity.Infrastructure.Persistence;
+using OpenTelemetry.Logs;
+using Serilog;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((context, services, configuration) =>
+{
+    configuration
+        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext()
+        .WriteTo.Console();
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFilename);
+    if (File.Exists(xmlPath))
+    {
+        options.IncludeXmlComments(xmlPath);
+    }
+});
+
+builder.Services.AddCorrelationContext();
+
+builder.Services.AddIdentityInfrastructure(builder.Configuration);
+
+builder.Services.AddOpenTelemetry().WithLogging(logging =>
+{
+    logging.AddConsoleExporter();
+});
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+app.UseSerilogRequestLogging();
+app.UseCorrelationContext();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapHealthChecks("/health", new HealthCheckOptions());
+app.MapGet("/ping", () => Results.Ok(new { status = "ok" }));
+
+app.MapPost("/register", async (
+    RegisterUserCommand command,
+    RegisterUserCommandHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var result = await handler.HandleAsync(command, cancellationToken);
+    return Results.Ok(result);
+});
+
+app.MapPost("/login", async (
+    LoginCommand command,
+    LoginCommandHandler handler,
+    CancellationToken cancellationToken) =>
+{
+    var result = await handler.HandleAsync(command, cancellationToken);
+    return Results.Ok(result);
+});
+
+app.MapGet("/users", async (UserQueries queries, CancellationToken cancellationToken) =>
+{
+    var users = await queries.GetAllAsync(cancellationToken);
+    return Results.Ok(users);
+});
+
+app.MapGet("/users/{id}", async (string id, UserQueries queries, CancellationToken cancellationToken) =>
+{
+    var user = await queries.GetByIdAsync(id, cancellationToken);
+    return user is null ? Results.NotFound() : Results.Ok(user);
+});
+
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<IdentityDbContext>();
+    var idGenerator = scope.ServiceProvider.GetRequiredService<MicroShop.BuildingBlocks.Abstractions.IdGeneration.IIdGenerator>();
+    await IdentityDbContextSeeder.SeedAsync(dbContext, idGenerator);
+}
+
+app.Run();
+
+public partial class Program;

--- a/src/Services/Identity/API/Properties/launchSettings.json
+++ b/src/Services/Identity/API/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "MicroShop.Services.Identity.API": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:5002;http://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Services/Identity/API/appsettings.Development.json
+++ b/src/Services/Identity/API/appsettings.Development.json
@@ -1,0 +1,14 @@
+{
+  "ConnectionStrings": {
+    "Identity": "Server=localhost,1433;Database=MicroShop_Identity;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+  },
+  "Jwt": {
+    "PrivateKeyPath": "./deploy/compose/identity-secrets/identity_rsa_private.pem",
+    "PublicKeyPath": "./deploy/compose/identity-secrets/identity_rsa_public.pem"
+  },
+  "RabbitMQ": {
+    "Host": "localhost",
+    "Username": "guest",
+    "Password": "guest"
+  }
+}

--- a/src/Services/Identity/API/appsettings.json
+++ b/src/Services/Identity/API/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Identity": "Server=localhost;Database=MicroShop_Identity;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
+  },
+  "Jwt": {
+    "Issuer": "MicroShop.Identity",
+    "Audience": "MicroShop",
+    "AccessTokenExpirationMinutes": 60,
+    "PrivateKeyPath": "./deploy/compose/identity-secrets/identity_rsa_private.pem",
+    "PublicKeyPath": "./deploy/compose/identity-secrets/identity_rsa_public.pem"
+  },
+  "RabbitMQ": {
+    "Host": "rabbitmq",
+    "Username": "guest",
+    "Password": "guest"
+  }
+}

--- a/src/Services/Identity/Application/Abstractions/IPasswordHasherService.cs
+++ b/src/Services/Identity/Application/Abstractions/IPasswordHasherService.cs
@@ -1,0 +1,17 @@
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Application.Abstractions;
+
+public interface IPasswordHasherService
+{
+    string HashPassword(User user, string password);
+
+    PasswordVerificationResult VerifyHashedPassword(User user, string hashedPassword, string providedPassword);
+}
+
+public enum PasswordVerificationResult
+{
+    Failed = 0,
+    Success = 1,
+    SuccessRehashNeeded = 2
+}

--- a/src/Services/Identity/Application/Abstractions/IRoleRepository.cs
+++ b/src/Services/Identity/Application/Abstractions/IRoleRepository.cs
@@ -1,0 +1,10 @@
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Application.Abstractions;
+
+public interface IRoleRepository
+{
+    Task<Role?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<Role>> GetDefaultRolesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Services/Identity/Application/Abstractions/ITokenService.cs
+++ b/src/Services/Identity/Application/Abstractions/ITokenService.cs
@@ -1,0 +1,9 @@
+using MicroShop.Services.Identity.Application.Authentication.Models;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Application.Abstractions;
+
+public interface ITokenService
+{
+    Task<AuthResultDto> CreateTokenAsync(User user, CancellationToken cancellationToken = default);
+}

--- a/src/Services/Identity/Application/Abstractions/IUserIntegrationEventPublisher.cs
+++ b/src/Services/Identity/Application/Abstractions/IUserIntegrationEventPublisher.cs
@@ -1,0 +1,8 @@
+using MicroShop.Services.Identity.Application.Users.Models;
+
+namespace MicroShop.Services.Identity.Application.Abstractions;
+
+public interface IUserIntegrationEventPublisher
+{
+    Task PublishUserRegisteredAsync(UserRegisteredIntegrationEventDto payload, CancellationToken cancellationToken = default);
+}

--- a/src/Services/Identity/Application/Abstractions/IUserRepository.cs
+++ b/src/Services/Identity/Application/Abstractions/IUserRepository.cs
@@ -1,0 +1,18 @@
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Application.Abstractions;
+
+public interface IUserRepository
+{
+    Task<User?> FindByIdAsync(string id, CancellationToken cancellationToken = default);
+
+    Task<User?> FindByUsernameAsync(string username, CancellationToken cancellationToken = default);
+
+    Task<User?> FindByEmailAsync(string email, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyCollection<User>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task AddAsync(User user, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(User user, CancellationToken cancellationToken = default);
+}

--- a/src/Services/Identity/Application/Authentication/Commands/LoginCommand.cs
+++ b/src/Services/Identity/Application/Authentication/Commands/LoginCommand.cs
@@ -1,0 +1,3 @@
+namespace MicroShop.Services.Identity.Application.Authentication.Commands;
+
+public sealed record LoginCommand(string UsernameOrEmail, string Password);

--- a/src/Services/Identity/Application/Authentication/Commands/LoginCommandHandler.cs
+++ b/src/Services/Identity/Application/Authentication/Commands/LoginCommandHandler.cs
@@ -1,0 +1,57 @@
+using FluentValidation;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Authentication.Models;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Application.Authentication.Commands;
+
+public sealed class LoginCommandHandler
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHasherService _passwordHasher;
+    private readonly ITokenService _tokenService;
+    private readonly IValidator<LoginCommand> _validator;
+
+    public LoginCommandHandler(
+        IUserRepository userRepository,
+        IPasswordHasherService passwordHasher,
+        ITokenService tokenService,
+        IValidator<LoginCommand> validator)
+    {
+        _userRepository = userRepository;
+        _passwordHasher = passwordHasher;
+        _tokenService = tokenService;
+        _validator = validator;
+    }
+
+    public async Task<AuthResultDto> HandleAsync(LoginCommand command, CancellationToken cancellationToken = default)
+    {
+        await _validator.ValidateAndThrowAsync(command, cancellationToken);
+
+        User? user = await _userRepository.FindByUsernameAsync(command.UsernameOrEmail, cancellationToken);
+        if (user is null && command.UsernameOrEmail.Contains('@', StringComparison.Ordinal))
+        {
+            user = await _userRepository.FindByEmailAsync(command.UsernameOrEmail, cancellationToken);
+        }
+
+        if (user is null)
+        {
+            throw new UnauthorizedAccessException("Invalid credentials.");
+        }
+
+        var verification = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, command.Password);
+        if (verification == PasswordVerificationResult.Failed)
+        {
+            throw new UnauthorizedAccessException("Invalid credentials.");
+        }
+
+        if (verification == PasswordVerificationResult.SuccessRehashNeeded)
+        {
+            var newHash = _passwordHasher.HashPassword(user, command.Password);
+            user.UpdatePasswordHash(newHash);
+            await _userRepository.UpdateAsync(user, cancellationToken);
+        }
+
+        return await _tokenService.CreateTokenAsync(user, cancellationToken);
+    }
+}

--- a/src/Services/Identity/Application/Authentication/Commands/RegisterUserCommand.cs
+++ b/src/Services/Identity/Application/Authentication/Commands/RegisterUserCommand.cs
@@ -1,0 +1,3 @@
+namespace MicroShop.Services.Identity.Application.Authentication.Commands;
+
+public sealed record RegisterUserCommand(string Username, string Email, string Password);

--- a/src/Services/Identity/Application/Authentication/Commands/RegisterUserCommandHandler.cs
+++ b/src/Services/Identity/Application/Authentication/Commands/RegisterUserCommandHandler.cs
@@ -1,0 +1,93 @@
+using FluentValidation;
+using MicroShop.BuildingBlocks.Abstractions.IdGeneration;
+using MicroShop.BuildingBlocks.Abstractions.Time;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Authentication.Models;
+using MicroShop.Services.Identity.Application.Users.Models;
+using MicroShop.Services.Identity.Domain.Entities;
+using System.Linq;
+
+namespace MicroShop.Services.Identity.Application.Authentication.Commands;
+
+public sealed class RegisterUserCommandHandler
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IRoleRepository _roleRepository;
+    private readonly IPasswordHasherService _passwordHasher;
+    private readonly ITokenService _tokenService;
+    private readonly IUserIntegrationEventPublisher _eventPublisher;
+    private readonly IValidator<RegisterUserCommand> _validator;
+    private readonly IIdGenerator _idGenerator;
+    private readonly IClock _clock;
+
+    public RegisterUserCommandHandler(
+        IUserRepository userRepository,
+        IRoleRepository roleRepository,
+        IPasswordHasherService passwordHasher,
+        ITokenService tokenService,
+        IUserIntegrationEventPublisher eventPublisher,
+        IValidator<RegisterUserCommand> validator,
+        IIdGenerator idGenerator,
+        IClock clock)
+    {
+        _userRepository = userRepository;
+        _roleRepository = roleRepository;
+        _passwordHasher = passwordHasher;
+        _tokenService = tokenService;
+        _eventPublisher = eventPublisher;
+        _validator = validator;
+        _idGenerator = idGenerator;
+        _clock = clock;
+    }
+
+    public async Task<AuthResultDto> HandleAsync(RegisterUserCommand command, CancellationToken cancellationToken = default)
+    {
+        await _validator.ValidateAndThrowAsync(command, cancellationToken);
+
+        var existingByUsername = await _userRepository.FindByUsernameAsync(command.Username, cancellationToken);
+        if (existingByUsername is not null)
+        {
+            throw new InvalidOperationException("Username already taken.");
+        }
+
+        var existingByEmail = await _userRepository.FindByEmailAsync(command.Email, cancellationToken);
+        if (existingByEmail is not null)
+        {
+            throw new InvalidOperationException("Email already registered.");
+        }
+
+        var defaultRoles = await _roleRepository.GetDefaultRolesAsync(cancellationToken);
+        if (defaultRoles.Count == 0)
+        {
+            throw new InvalidOperationException("No default roles are configured.");
+        }
+
+        var user = User.Create(
+            _idGenerator,
+            _clock,
+            command.Username,
+            command.Email,
+            string.Empty,
+            defaultRoles);
+
+        var passwordHash = _passwordHasher.HashPassword(user, command.Password);
+        user.UpdatePasswordHash(passwordHash);
+
+        await _userRepository.AddAsync(user, cancellationToken);
+
+        var token = await _tokenService.CreateTokenAsync(user, cancellationToken);
+
+        var integrationEvent = new UserRegisteredIntegrationEventDto(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.Roles.Select(role => role.Name).ToArray(),
+            user.CreatedAt);
+
+        await _eventPublisher.PublishUserRegisteredAsync(integrationEvent, cancellationToken);
+
+        user.ClearDomainEvents();
+
+        return token;
+    }
+}

--- a/src/Services/Identity/Application/Authentication/Models/AuthResultDto.cs
+++ b/src/Services/Identity/Application/Authentication/Models/AuthResultDto.cs
@@ -1,0 +1,3 @@
+namespace MicroShop.Services.Identity.Application.Authentication.Models;
+
+public sealed record AuthResultDto(string AccessToken, DateTimeOffset ExpiresAt, string TokenType = "Bearer");

--- a/src/Services/Identity/Application/Authentication/Validators/LoginCommandValidator.cs
+++ b/src/Services/Identity/Application/Authentication/Validators/LoginCommandValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+using MicroShop.Services.Identity.Application.Authentication.Commands;
+
+namespace MicroShop.Services.Identity.Application.Authentication.Validators;
+
+public sealed class LoginCommandValidator : AbstractValidator<LoginCommand>
+{
+    public LoginCommandValidator()
+    {
+        RuleFor(x => x.UsernameOrEmail)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        RuleFor(x => x.Password)
+            .NotEmpty();
+    }
+}

--- a/src/Services/Identity/Application/Authentication/Validators/RegisterUserCommandValidator.cs
+++ b/src/Services/Identity/Application/Authentication/Validators/RegisterUserCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+using MicroShop.Services.Identity.Application.Authentication.Commands;
+
+namespace MicroShop.Services.Identity.Application.Authentication.Validators;
+
+public sealed class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty()
+            .MinimumLength(3)
+            .MaximumLength(64)
+            .Matches("^[a-zA-Z0-9_.-]+$");
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress();
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(8)
+            .Matches("[A-Z]").WithMessage("Password must contain an uppercase letter.")
+            .Matches("[a-z]").WithMessage("Password must contain a lowercase letter.")
+            .Matches("[0-9]").WithMessage("Password must contain a digit.")
+            .Matches("[!@#$%^&*()_+\-=\\[\\]{};':\"\\|,.<>\/?]").WithMessage("Password must contain a special character.");
+    }
+}

--- a/src/Services/Identity/Application/DependencyInjection.cs
+++ b/src/Services/Identity/Application/DependencyInjection.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using Microsoft.Extensions.DependencyInjection;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Authentication.Commands;
+using MicroShop.Services.Identity.Application.Authentication.Validators;
+using MicroShop.Services.Identity.Application.Users.Queries;
+
+namespace MicroShop.Services.Identity.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddIdentityApplication(this IServiceCollection services)
+    {
+        services.AddScoped<RegisterUserCommandHandler>();
+        services.AddScoped<LoginCommandHandler>();
+        services.AddScoped<UserQueries>();
+
+        services.AddScoped<IValidator<RegisterUserCommand>, RegisterUserCommandValidator>();
+        services.AddScoped<IValidator<LoginCommand>, LoginCommandValidator>();
+
+        return services;
+    }
+}

--- a/src/Services/Identity/Application/MicroShop.Services.Identity.Application.csproj
+++ b/src/Services/Identity/Application/MicroShop.Services.Identity.Application.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj" />
+    <ProjectReference Include="../Domain/MicroShop.Services.Identity.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Identity/Application/Users/Models/UserDto.cs
+++ b/src/Services/Identity/Application/Users/Models/UserDto.cs
@@ -1,0 +1,3 @@
+namespace MicroShop.Services.Identity.Application.Users.Models;
+
+public sealed record UserDto(string Id, string Username, string Email, IReadOnlyCollection<string> Roles, DateTimeOffset CreatedAt);

--- a/src/Services/Identity/Application/Users/Models/UserRegisteredIntegrationEventDto.cs
+++ b/src/Services/Identity/Application/Users/Models/UserRegisteredIntegrationEventDto.cs
@@ -1,0 +1,3 @@
+namespace MicroShop.Services.Identity.Application.Users.Models;
+
+public sealed record UserRegisteredIntegrationEventDto(string UserId, string Username, string Email, IReadOnlyCollection<string> Roles, DateTimeOffset RegisteredAt);

--- a/src/Services/Identity/Application/Users/Queries/UserQueries.cs
+++ b/src/Services/Identity/Application/Users/Queries/UserQueries.cs
@@ -1,0 +1,32 @@
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Users.Models;
+using System.Linq;
+
+namespace MicroShop.Services.Identity.Application.Users.Queries;
+
+public sealed class UserQueries
+{
+    private readonly IUserRepository _userRepository;
+
+    public UserQueries(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<UserDto?> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+    {
+        var user = await _userRepository.FindByIdAsync(id, cancellationToken);
+        return user is null
+            ? null
+            : new UserDto(user.Id, user.Username, user.Email, user.Roles.Select(role => role.Name).ToArray(), user.CreatedAt);
+    }
+
+    public async Task<IReadOnlyCollection<UserDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var users = await _userRepository.GetAllAsync(cancellationToken);
+        return users
+            .Select(user => new UserDto(user.Id, user.Username, user.Email, user.Roles.Select(role => role.Name).ToArray(), user.CreatedAt))
+            .OrderBy(user => user.Username, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+}

--- a/src/Services/Identity/Domain/Entities/DefaultRoles.cs
+++ b/src/Services/Identity/Domain/Entities/DefaultRoles.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MicroShop.Services.Identity.Domain.Entities;
+
+public static class DefaultRoles
+{
+    public const string Customer = "Customer";
+    public const string Admin = "Admin";
+
+    public static IReadOnlyCollection<string> All { get; } = new[] { Customer, Admin };
+}

--- a/src/Services/Identity/Domain/Entities/Role.cs
+++ b/src/Services/Identity/Domain/Entities/Role.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace MicroShop.Services.Identity.Domain.Entities;
+
+public sealed class Role : IEquatable<Role>
+{
+    public Role(string id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public static Role Create(string id, string name) => new(id, name);
+
+    public bool Equals(Role? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Id == other.Id;
+    }
+
+    public override bool Equals(object? obj) => obj is Role role && Equals(role);
+
+    public override int GetHashCode() => Id.GetHashCode(StringComparison.Ordinal);
+
+    public override string ToString() => Name;
+}

--- a/src/Services/Identity/Domain/Entities/User.cs
+++ b/src/Services/Identity/Domain/Entities/User.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using MicroShop.BuildingBlocks.Abstractions.IdGeneration;
+using MicroShop.BuildingBlocks.Abstractions.Time;
+using MicroShop.Services.Identity.Domain.Events;
+
+namespace MicroShop.Services.Identity.Domain.Entities;
+
+public sealed class User
+{
+    private readonly HashSet<Role> _roles = [];
+    private readonly List<UserDomainEvent> _domainEvents = [];
+
+    public User(string id, string username, string email, string passwordHash, DateTimeOffset createdAt)
+    {
+        Id = id;
+        Username = username;
+        Email = email;
+        PasswordHash = passwordHash;
+        CreatedAt = createdAt;
+    }
+
+    public string Id { get; }
+
+    public string Username { get; private set; }
+
+    public string Email { get; private set; }
+
+    public string PasswordHash { get; private set; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    public IReadOnlyCollection<Role> Roles => _roles;
+
+    public IReadOnlyCollection<UserDomainEvent> DomainEvents => _domainEvents;
+
+    public static User Create(
+        IIdGenerator idGenerator,
+        IClock clock,
+        string username,
+        string email,
+        string passwordHash,
+        IEnumerable<Role> roles)
+    {
+        ArgumentNullException.ThrowIfNull(idGenerator);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        var id = idGenerator.NewId();
+        var createdAt = clock.UtcNow;
+        var user = new User(id, username, email, passwordHash, createdAt);
+
+        foreach (var role in roles)
+        {
+            user.AssignRole(role);
+        }
+
+        user.AddDomainEvent(new UserRegisteredDomainEvent(user.Id, user.Username, user.Email, createdAt));
+
+        return user;
+    }
+
+    public void UpdatePasswordHash(string passwordHash)
+    {
+        PasswordHash = passwordHash;
+    }
+
+    public void AssignRole(Role role)
+    {
+        if (_roles.Add(role))
+        {
+            _domainEvents.Add(new UserRoleAssignedDomainEvent(Id, role.Name));
+        }
+    }
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+
+    private void AddDomainEvent(UserDomainEvent @event)
+    {
+        _domainEvents.Add(@event);
+    }
+}

--- a/src/Services/Identity/Domain/Events/UserDomainEvent.cs
+++ b/src/Services/Identity/Domain/Events/UserDomainEvent.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace MicroShop.Services.Identity.Domain.Events;
+
+public abstract record UserDomainEvent(DateTimeOffset OccurredOn);

--- a/src/Services/Identity/Domain/Events/UserRegisteredDomainEvent.cs
+++ b/src/Services/Identity/Domain/Events/UserRegisteredDomainEvent.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace MicroShop.Services.Identity.Domain.Events;
+
+public sealed record UserRegisteredDomainEvent(
+    string UserId,
+    string Username,
+    string Email,
+    DateTimeOffset RegisteredAt) : UserDomainEvent(RegisteredAt);

--- a/src/Services/Identity/Domain/Events/UserRoleAssignedDomainEvent.cs
+++ b/src/Services/Identity/Domain/Events/UserRoleAssignedDomainEvent.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace MicroShop.Services.Identity.Domain.Events;
+
+public sealed record UserRoleAssignedDomainEvent(string UserId, string RoleName)
+    : UserDomainEvent(DateTimeOffset.UtcNow);

--- a/src/Services/Identity/Domain/MicroShop.Services.Identity.Domain.csproj
+++ b/src/Services/Identity/Domain/MicroShop.Services.Identity.Domain.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Identity/Infrastructure/DependencyInjection/DependencyInjection.cs
+++ b/src/Services/Identity/Infrastructure/DependencyInjection/DependencyInjection.cs
@@ -1,0 +1,83 @@
+using MassTransit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MicroShop.BuildingBlocks.Abstractions.IdGeneration;
+using MicroShop.BuildingBlocks.Abstractions.Time;
+using MicroShop.Services.Identity.Application;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Infrastructure.Messaging;
+using MicroShop.Services.Identity.Infrastructure.Persistence;
+using MicroShop.Services.Identity.Infrastructure.Persistence.Repositories;
+using MicroShop.Services.Identity.Infrastructure.Security;
+
+namespace MicroShop.Services.Identity.Infrastructure.DependencyInjection;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddIdentityInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddIdentityApplication();
+
+        services.Configure<JwtOptions>(configuration.GetSection(JwtOptions.SectionName));
+
+        services.AddDbContext<IdentityDbContext>(options =>
+        {
+            var connectionString = configuration.GetConnectionString("Identity")
+                ?? throw new InvalidOperationException("Connection string 'Identity' is not configured.");
+
+            options.UseSqlServer(connectionString, sqlOptions =>
+            {
+                sqlOptions.EnableRetryOnFailure();
+                sqlOptions.MigrationsAssembly(typeof(IdentityDbContext).Assembly.FullName);
+            });
+        });
+
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IRoleRepository, RoleRepository>();
+        services.AddScoped<IPasswordHasherService, PasswordHasherService>();
+        services.AddScoped<ITokenService, JwtTokenService>();
+        services.AddScoped<IUserIntegrationEventPublisher, UserIntegrationEventPublisher>();
+
+        services.AddScoped<IPasswordHasher<Domain.Entities.User>, PasswordHasher<Domain.Entities.User>>();
+
+        services.AddMassTransit(busConfigurator =>
+        {
+            busConfigurator.SetKebabCaseEndpointNameFormatter();
+            busConfigurator.UsingRabbitMq((context, cfg) =>
+            {
+                var rabbitMqOptions = configuration.GetSection("RabbitMQ");
+                var host = rabbitMqOptions.GetValue<string>("Host") ?? "rabbitmq";
+                var username = rabbitMqOptions.GetValue<string>("Username") ?? "guest";
+                var password = rabbitMqOptions.GetValue<string>("Password") ?? "guest";
+
+                cfg.Host(host, h =>
+                {
+                    h.Username(username);
+                    h.Password(password);
+                });
+
+                cfg.ConfigureEndpoints(context);
+            });
+        });
+
+        services.AddOptions<JwtBearerOptions>().Configure(options => { });
+
+        services.AddHealthChecks().AddDbContextCheck<IdentityDbContext>(name: "IdentityDb");
+
+        services.AddOpenTelemetry()
+            .WithTracing(builder =>
+            {
+                builder.AddAspNetCoreInstrumentation();
+                builder.AddHttpClientInstrumentation();
+                builder.AddSqlClientInstrumentation();
+                builder.AddSource("MassTransit");
+            });
+
+        services.AddSingleton<IClock, SystemClock>();
+        services.AddSingleton<IIdGenerator, UlidIdGenerator>();
+
+        return services;
+    }
+}

--- a/src/Services/Identity/Infrastructure/Messaging/Events/UserRegisteredIntegrationEventV1.cs
+++ b/src/Services/Identity/Infrastructure/Messaging/Events/UserRegisteredIntegrationEventV1.cs
@@ -1,0 +1,10 @@
+using MicroShop.BuildingBlocks.Contracts.Messaging;
+
+namespace MicroShop.Services.Identity.Infrastructure.Messaging.Events;
+
+public sealed record UserRegisteredIntegrationEventV1(
+    string UserId,
+    string Username,
+    string Email,
+    IReadOnlyCollection<string> Roles,
+    DateTimeOffset RegisteredAt) : IIntegrationEvent;

--- a/src/Services/Identity/Infrastructure/Messaging/UserIntegrationEventPublisher.cs
+++ b/src/Services/Identity/Infrastructure/Messaging/UserIntegrationEventPublisher.cs
@@ -1,0 +1,15 @@
+using MassTransit;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Users.Models;
+using MicroShop.Services.Identity.Infrastructure.Messaging.Events;
+
+namespace MicroShop.Services.Identity.Infrastructure.Messaging;
+
+internal sealed class UserIntegrationEventPublisher(IBus bus) : IUserIntegrationEventPublisher
+{
+    public async Task PublishUserRegisteredAsync(UserRegisteredIntegrationEventDto payload, CancellationToken cancellationToken = default)
+    {
+        var message = new UserRegisteredIntegrationEventV1(payload.UserId, payload.Username, payload.Email, payload.Roles, payload.RegisteredAt);
+        await bus.Publish(message, cancellationToken);
+    }
+}

--- a/src/Services/Identity/Infrastructure/MicroShop.Services.Identity.Infrastructure.csproj
+++ b/src/Services/Identity/Infrastructure/MicroShop.Services.Identity.Infrastructure.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MassTransit" Version="8.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="9.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../BuildingBlocks/Abstractions/MicroShop.BuildingBlocks.Abstractions.csproj" />
+    <ProjectReference Include="../../../BuildingBlocks/Contracts/MicroShop.BuildingBlocks.Contracts.csproj" />
+    <ProjectReference Include="../Application/MicroShop.Services.Identity.Application.csproj" />
+    <ProjectReference Include="../Domain/MicroShop.Services.Identity.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Identity/Infrastructure/Persistence/Configurations/RoleConfiguration.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Configurations/RoleConfiguration.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Configurations;
+
+internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
+{
+    public void Configure(EntityTypeBuilder<Role> builder)
+    {
+        builder.ToTable("Roles");
+
+        builder.HasKey(role => role.Id);
+
+        builder.Property(role => role.Id)
+            .HasMaxLength(26)
+            .IsRequired();
+
+        builder.Property(role => role.Name)
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.HasIndex(role => role.Name).IsUnique();
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Configurations;
+
+internal sealed class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.ToTable("Users");
+
+        builder.HasKey(user => user.Id);
+
+        builder.Property(user => user.Id)
+            .HasMaxLength(26)
+            .IsRequired();
+
+        builder.Property(user => user.Username)
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(user => user.Email)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(user => user.PasswordHash)
+            .HasMaxLength(512)
+            .IsRequired();
+
+        builder.Property(user => user.CreatedAt)
+            .IsRequired();
+
+        builder.Metadata.FindNavigation(nameof(User.Roles))?.SetPropertyAccessMode(PropertyAccessMode.Field);
+
+        builder.HasMany<Role>("_roles")
+            .WithMany()
+            .UsingEntity<Dictionary<string, object>>(
+                "UserRoles",
+                right => right.HasOne<Role>().WithMany().HasForeignKey("RoleId").OnDelete(DeleteBehavior.Cascade),
+                left => left.HasOne<User>().WithMany().HasForeignKey("UserId").OnDelete(DeleteBehavior.Cascade),
+                join =>
+                {
+                    join.HasKey("UserId", "RoleId");
+                    join.ToTable("UserRoles");
+                });
+
+        builder.HasIndex(user => user.Username).IsUnique();
+        builder.HasIndex(user => user.Email).IsUnique();
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/IdentityDbContext.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/IdentityDbContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence;
+
+public sealed class IdentityDbContext(DbContextOptions<IdentityDbContext> options) : DbContext(options)
+{
+    public DbSet<User> Users => Set<User>();
+
+    public DbSet<Role> Roles => Set<Role>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdentityDbContext).Assembly);
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/IdentityDbContextSeeder.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/IdentityDbContextSeeder.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using MicroShop.BuildingBlocks.Abstractions.IdGeneration;
+using MicroShop.Services.Identity.Domain.Entities;
+using System.Linq;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence;
+
+public static class IdentityDbContextSeeder
+{
+    public static async Task SeedAsync(IdentityDbContext dbContext, IIdGenerator idGenerator, CancellationToken cancellationToken = default)
+    {
+        await dbContext.Database.MigrateAsync(cancellationToken);
+
+        if (!await dbContext.Roles.AnyAsync(cancellationToken))
+        {
+            var roles = DefaultRoles.All
+                .Select(roleName => Role.Create(idGenerator.NewId(), roleName))
+                .ToArray();
+
+            await dbContext.Roles.AddRangeAsync(roles, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/Migrations/20241010120000_InitialIdentity.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Migrations/20241010120000_InitialIdentity.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Roles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(26)", maxLength: 26, nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Roles", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(26)", maxLength: 26, nullable: false),
+                    Username = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserRoles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(26)", nullable: false),
+                    RoleId = table.Column<string>(type: "nvarchar(26)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserRoles", x => new { x.UserId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_UserRoles_Roles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserRoles_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Roles_Name",
+                table: "Roles",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRoles_RoleId",
+                table: "UserRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Username",
+                table: "Users",
+                column: "Username",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserRoles");
+
+            migrationBuilder.DropTable(
+                name: "Roles");
+
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/Migrations/IdentityDbContextModelSnapshot.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Migrations/IdentityDbContextModelSnapshot.cs
@@ -1,0 +1,102 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MicroShop.Services.Identity.Infrastructure.Persistence;
+
+#nullable disable
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Migrations
+{
+    [DbContext(typeof(IdentityDbContext))]
+    partial class IdentityDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("MicroShop.Services.Identity.Domain.Entities.Role", b =>
+            {
+                b.Property<string>("Id")
+                    .HasMaxLength(26)
+                    .HasColumnType("nvarchar(26)");
+
+                b.Property<string>("Name")
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("Name")
+                    .IsUnique();
+
+                b.ToTable("Roles");
+            });
+
+            modelBuilder.Entity("MicroShop.Services.Identity.Domain.Entities.User", b =>
+            {
+                b.Property<string>("Id")
+                    .HasMaxLength(26)
+                    .HasColumnType("nvarchar(26)");
+
+                b.Property<DateTimeOffset>("CreatedAt")
+                    .HasColumnType("datetimeoffset");
+
+                b.Property<string>("Email")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
+
+                b.Property<string>("PasswordHash")
+                    .HasMaxLength(512)
+                    .HasColumnType("nvarchar(512)");
+
+                b.Property<string>("Username")
+                    .HasMaxLength(64)
+                    .HasColumnType("nvarchar(64)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("Email")
+                    .IsUnique();
+
+                b.HasIndex("Username")
+                    .IsUnique();
+
+                b.ToTable("Users");
+            });
+
+            modelBuilder.Entity("UserRoles", b =>
+            {
+                b.Property<string>("UserId")
+                    .HasColumnType("nvarchar(26)");
+
+                b.Property<string>("RoleId")
+                    .HasColumnType("nvarchar(26)");
+
+                b.HasKey("UserId", "RoleId");
+
+                b.HasIndex("RoleId");
+
+                b.ToTable("UserRoles");
+
+                b.HasOne("MicroShop.Services.Identity.Domain.Entities.Role", null)
+                    .WithMany()
+                    .HasForeignKey("RoleId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("MicroShop.Services.Identity.Domain.Entities.User", null)
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/src/Services/Identity/Infrastructure/Persistence/Repositories/RoleRepository.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Repositories/RoleRepository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Repositories;
+
+internal sealed class RoleRepository(IdentityDbContext dbContext) : IRoleRepository
+{
+    public async Task<Role?> FindByNameAsync(string name, CancellationToken cancellationToken = default)
+        => await dbContext.Roles.FirstOrDefaultAsync(role => role.Name == name, cancellationToken);
+
+    public async Task<IReadOnlyCollection<Role>> GetDefaultRolesAsync(CancellationToken cancellationToken = default)
+        => await dbContext.Roles
+            .Where(role => DefaultRoles.All.Contains(role.Name))
+            .OrderBy(role => role.Name)
+            .ToListAsync(cancellationToken);
+}

--- a/src/Services/Identity/Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/src/Services/Identity/Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Persistence.Repositories;
+
+internal sealed class UserRepository(IdentityDbContext dbContext) : IUserRepository
+{
+    public async Task<User?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+        => await dbContext.Users
+            .Include(user => EF.Property<ICollection<Role>>(user, "_roles"))
+            .FirstOrDefaultAsync(user => user.Id == id, cancellationToken);
+
+    public async Task<User?> FindByUsernameAsync(string username, CancellationToken cancellationToken = default)
+        => await dbContext.Users
+            .Include(user => EF.Property<ICollection<Role>>(user, "_roles"))
+            .FirstOrDefaultAsync(user => user.Username == username, cancellationToken);
+
+    public async Task<User?> FindByEmailAsync(string email, CancellationToken cancellationToken = default)
+        => await dbContext.Users
+            .Include(user => EF.Property<ICollection<Role>>(user, "_roles"))
+            .FirstOrDefaultAsync(user => user.Email == email, cancellationToken);
+
+    public async Task<IReadOnlyCollection<User>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await dbContext.Users
+            .Include(user => EF.Property<ICollection<Role>>(user, "_roles"))
+            .OrderBy(user => user.Username)
+            .ToListAsync(cancellationToken);
+
+    public async Task AddAsync(User user, CancellationToken cancellationToken = default)
+    {
+        await dbContext.Users.AddAsync(user, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(User user, CancellationToken cancellationToken = default)
+    {
+        dbContext.Users.Update(user);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Services/Identity/Infrastructure/Security/JwtOptions.cs
+++ b/src/Services/Identity/Infrastructure/Security/JwtOptions.cs
@@ -1,0 +1,16 @@
+namespace MicroShop.Services.Identity.Infrastructure.Security;
+
+public sealed class JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    public string Issuer { get; set; } = string.Empty;
+
+    public string Audience { get; set; } = string.Empty;
+
+    public int AccessTokenExpirationMinutes { get; set; } = 60;
+
+    public string PrivateKeyPath { get; set; } = string.Empty;
+
+    public string PublicKeyPath { get; set; } = string.Empty;
+}

--- a/src/Services/Identity/Infrastructure/Security/JwtTokenService.cs
+++ b/src/Services/Identity/Infrastructure/Security/JwtTokenService.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using MicroShop.BuildingBlocks.Abstractions.Time;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Application.Authentication.Models;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Security;
+
+internal sealed class JwtTokenService : ITokenService
+{
+    private readonly JwtSecurityTokenHandler _tokenHandler = new();
+    private readonly JwtOptions _options;
+    private readonly ILogger<JwtTokenService> _logger;
+    private readonly IClock _clock;
+    private readonly SemaphoreSlim _keySemaphore = new(1, 1);
+    private SecurityKey? _signingKey;
+
+    public JwtTokenService(IOptions<JwtOptions> options, ILogger<JwtTokenService> logger, IClock clock)
+    {
+        _options = options.Value;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public async Task<AuthResultDto> CreateTokenAsync(User user, CancellationToken cancellationToken = default)
+    {
+        await EnsureSigningKeyAsync(cancellationToken);
+
+        if (_signingKey is null)
+        {
+            throw new InvalidOperationException("Signing key is not available.");
+        }
+
+        var expires = _clock.UtcNow.AddMinutes(_options.AccessTokenExpirationMinutes);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id),
+            new(JwtRegisteredClaimNames.UniqueName, user.Username),
+            new(JwtRegisteredClaimNames.Email, user.Email),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        claims.AddRange(user.Roles.Select(role => new Claim(ClaimTypes.Role, role.Name)));
+
+        var credentials = new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256);
+
+        var jwt = new JwtSecurityToken(
+            issuer: _options.Issuer,
+            audience: _options.Audience,
+            claims: claims,
+            notBefore: _clock.UtcNow.UtcDateTime,
+            expires: expires.UtcDateTime,
+            signingCredentials: credentials);
+
+        var token = _tokenHandler.WriteToken(jwt);
+
+        return new AuthResultDto(token, expires);
+    }
+
+    private async Task EnsureSigningKeyAsync(CancellationToken cancellationToken)
+    {
+        if (_signingKey is not null)
+        {
+            return;
+        }
+
+        await _keySemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (_signingKey is not null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.PrivateKeyPath))
+            {
+                throw new InvalidOperationException("Jwt:PrivateKeyPath configuration is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.PublicKeyPath))
+            {
+                throw new InvalidOperationException("Jwt:PublicKeyPath configuration is required.");
+            }
+
+            EnsureKeyDirectoryExists(_options.PrivateKeyPath);
+            EnsureKeyDirectoryExists(_options.PublicKeyPath);
+
+            if (!File.Exists(_options.PrivateKeyPath) || !File.Exists(_options.PublicKeyPath))
+            {
+                _logger.LogWarning("JWT key files not found. Generating new RSA key pair at {PrivateKeyPath} and {PublicKeyPath}.", _options.PrivateKeyPath, _options.PublicKeyPath);
+                GenerateAndPersistKeys();
+            }
+
+            var privateKeyPem = await File.ReadAllTextAsync(_options.PrivateKeyPath, cancellationToken);
+            using var rsa = RSA.Create();
+            rsa.ImportFromPem(privateKeyPem);
+            _signingKey = new RsaSecurityKey(rsa.ExportParameters(includePrivateParameters: true))
+            {
+                KeyId = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(32))
+            };
+        }
+        finally
+        {
+            _keySemaphore.Release();
+        }
+    }
+
+    private static void EnsureKeyDirectoryExists(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    private void GenerateAndPersistKeys()
+    {
+        using var rsa = RSA.Create(4096);
+        var privateKey = ExportPrivateKeyPem(rsa);
+        var publicKey = ExportPublicKeyPem(rsa);
+
+        File.WriteAllText(_options.PrivateKeyPath, privateKey, Encoding.UTF8);
+        File.WriteAllText(_options.PublicKeyPath, publicKey, Encoding.UTF8);
+    }
+
+    private static string ExportPrivateKeyPem(RSA rsa)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("-----BEGIN RSA PRIVATE KEY-----");
+        builder.AppendLine(Convert.ToBase64String(rsa.ExportRSAPrivateKey(), Base64FormattingOptions.InsertLineBreaks));
+        builder.AppendLine("-----END RSA PRIVATE KEY-----");
+        return builder.ToString();
+    }
+
+    private static string ExportPublicKeyPem(RSA rsa)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("-----BEGIN RSA PUBLIC KEY-----");
+        builder.AppendLine(Convert.ToBase64String(rsa.ExportRSAPublicKey(), Base64FormattingOptions.InsertLineBreaks));
+        builder.AppendLine("-----END RSA PUBLIC KEY-----");
+        return builder.ToString();
+    }
+}

--- a/src/Services/Identity/Infrastructure/Security/PasswordHasherService.cs
+++ b/src/Services/Identity/Infrastructure/Security/PasswordHasherService.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Identity;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Domain.Entities;
+
+namespace MicroShop.Services.Identity.Infrastructure.Security;
+
+internal sealed class PasswordHasherService : IPasswordHasherService
+{
+    private readonly IPasswordHasher<User> _passwordHasher;
+
+    public PasswordHasherService(IPasswordHasher<User> passwordHasher)
+    {
+        _passwordHasher = passwordHasher;
+    }
+
+    public string HashPassword(User user, string password) => _passwordHasher.HashPassword(user, password);
+
+    public PasswordVerificationResult VerifyHashedPassword(User user, string hashedPassword, string providedPassword)
+        => _passwordHasher.VerifyHashedPassword(user, hashedPassword, providedPassword) switch
+        {
+            Microsoft.AspNetCore.Identity.PasswordVerificationResult.Success => PasswordVerificationResult.Success,
+            Microsoft.AspNetCore.Identity.PasswordVerificationResult.SuccessRehashNeeded => PasswordVerificationResult.SuccessRehashNeeded,
+            _ => PasswordVerificationResult.Failed
+        };
+}

--- a/tests/Services.Identity.Tests/Integration/IdentityApiFixture.cs
+++ b/tests/Services.Identity.Tests/Integration/IdentityApiFixture.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Testcontainers.RabbitMq;
+using Testcontainers.SqlEdge;
+
+namespace MicroShop.Services.Identity.Tests.Integration;
+
+public sealed class IdentityApiFixture : IAsyncLifetime
+{
+    private readonly SqlEdgeContainer _sqlContainer;
+    private readonly RabbitMqContainer _rabbitContainer;
+    private readonly string _keysDirectory;
+
+    public IdentityApiFixture()
+    {
+        _sqlContainer = new SqlEdgeBuilder()
+            .WithPassword("yourStrong(!)Password")
+            .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithImage("mcr.microsoft.com/azure-sql-edge:latest")
+            .WithCleanUp(true)
+            .Build();
+
+        _rabbitContainer = new RabbitMqBuilder()
+            .WithImage("rabbitmq:3.13-management")
+            .WithCleanUp(true)
+            .Build();
+
+        _keysDirectory = Path.Combine(Path.GetTempPath(), "identity-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_keysDirectory);
+    }
+
+    public HttpClient Client { get; private set; } = default!;
+
+    public WebApplicationFactory<Program> Factory { get; private set; } = default!;
+
+    public async Task InitializeAsync()
+    {
+        await _sqlContainer.StartAsync();
+        await _rabbitContainer.StartAsync();
+
+        var connectionString = _sqlContainer.GetConnectionString();
+        var jwtPrivateKey = Path.Combine(_keysDirectory, "identity_rsa_private.pem");
+        var jwtPublicKey = Path.Combine(_keysDirectory, "identity_rsa_public.pem");
+
+        Factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("ConnectionStrings:Identity", connectionString);
+            builder.UseSetting("Jwt:PrivateKeyPath", jwtPrivateKey);
+            builder.UseSetting("Jwt:PublicKeyPath", jwtPublicKey);
+            builder.UseSetting("Jwt:Issuer", "MicroShop.Identity.Tests");
+            builder.UseSetting("Jwt:Audience", "MicroShop.Tests");
+            builder.UseSetting("RabbitMQ:Host", _rabbitContainer.Hostname);
+            builder.UseSetting("RabbitMQ:Username", _rabbitContainer.Username);
+            builder.UseSetting("RabbitMQ:Password", _rabbitContainer.Password);
+            builder.UseSetting("DOTNET_ENVIRONMENT", "Development");
+            builder.ConfigureAppConfiguration((context, config) =>
+            {
+                var overrides = new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:Identity"] = connectionString,
+                    ["Jwt:PrivateKeyPath"] = jwtPrivateKey,
+                    ["Jwt:PublicKeyPath"] = jwtPublicKey,
+                    ["Jwt:Issuer"] = "MicroShop.Identity.Tests",
+                    ["Jwt:Audience"] = "MicroShop.Tests",
+                    ["RabbitMQ:Host"] = _rabbitContainer.Hostname,
+                    ["RabbitMQ:Username"] = _rabbitContainer.Username,
+                    ["RabbitMQ:Password"] = _rabbitContainer.Password
+                };
+
+                config.AddInMemoryCollection(overrides!);
+            });
+        });
+
+        Client = Factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("http://localhost"),
+            AllowAutoRedirect = false
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        Factory?.Dispose();
+
+        if (_sqlContainer.IsRunning)
+        {
+            await _sqlContainer.StopAsync();
+        }
+
+        if (_rabbitContainer.IsRunning)
+        {
+            await _rabbitContainer.StopAsync();
+        }
+
+        await _sqlContainer.DisposeAsync();
+        await _rabbitContainer.DisposeAsync();
+
+        if (Directory.Exists(_keysDirectory))
+        {
+            Directory.Delete(_keysDirectory, true);
+        }
+    }
+}

--- a/tests/Services.Identity.Tests/Integration/IdentityApiTests.cs
+++ b/tests/Services.Identity.Tests/Integration/IdentityApiTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MicroShop.Services.Identity.Application.Authentication.Commands;
+using MicroShop.Services.Identity.Application.Authentication.Models;
+using MicroShop.Services.Identity.Application.Users.Models;
+using Xunit;
+
+namespace MicroShop.Services.Identity.Tests.Integration;
+
+[CollectionDefinition(nameof(IdentityApiCollection))]
+public sealed class IdentityApiCollection : ICollectionFixture<IdentityApiFixture>;
+
+public sealed class IdentityApiTests(IdentityApiFixture fixture)
+{
+    private readonly HttpClient _client = fixture.Client;
+
+    [Fact]
+    public async Task Register_Login_ListUsers_ShouldWork()
+    {
+        var registerCommand = new RegisterUserCommand("integration-user", "integration@example.com", "Strong!Pass123");
+        var registerResponse = await _client.PostAsJsonAsync("/register", registerCommand);
+
+        registerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var registerResult = await registerResponse.Content.ReadFromJsonAsync<AuthResultDto>();
+        registerResult.Should().NotBeNull();
+        registerResult!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        var loginCommand = new LoginCommand(registerCommand.Username, registerCommand.Password);
+        var loginResponse = await _client.PostAsJsonAsync("/login", loginCommand);
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<AuthResultDto>();
+        loginResult.Should().NotBeNull();
+        loginResult!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        var users = await _client.GetFromJsonAsync<IReadOnlyCollection<UserDto>>("/users");
+        users.Should().NotBeNull();
+        var registeredUser = users!.Single(user => user.Username == registerCommand.Username);
+
+        var user = await _client.GetFromJsonAsync<UserDto>($"/users/{registeredUser.Id}");
+        user.Should().NotBeNull();
+        user!.Email.Should().Be(registerCommand.Email);
+    }
+}

--- a/tests/Services.Identity.Tests/MicroShop.Services.Identity.Tests.csproj
+++ b/tests/Services.Identity.Tests/MicroShop.Services.Identity.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Testcontainers" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.SqlEdge" Version="3.9.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="3.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Services/Identity/Application/MicroShop.Services.Identity.Application.csproj" />
+    <ProjectReference Include="../../src/Services/Identity/API/MicroShop.Services.Identity.API.csproj" />
+    <ProjectReference Include="../../src/Services/Identity/Infrastructure/MicroShop.Services.Identity.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Services.Identity.Tests/Security/JwtTokenServiceTests.cs
+++ b/tests/Services.Identity.Tests/Security/JwtTokenServiceTests.cs
@@ -1,0 +1,63 @@
+using System.IdentityModel.Tokens.Jwt;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MicroShop.BuildingBlocks.Abstractions.Time;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Domain.Entities;
+using MicroShop.Services.Identity.Infrastructure.Security;
+using Xunit;
+
+namespace MicroShop.Services.Identity.Tests.Security;
+
+public class JwtTokenServiceTests
+{
+    [Fact]
+    public async Task CreateTokenAsync_ShouldEmitSignedToken()
+    {
+        using var tempDirectory = new TempDirectory();
+        var options = Options.Create(new JwtOptions
+        {
+            Issuer = "MicroShop.Identity",
+            Audience = "MicroShop",
+            AccessTokenExpirationMinutes = 5,
+            PrivateKeyPath = Path.Combine(tempDirectory.Path, "private.pem"),
+            PublicKeyPath = Path.Combine(tempDirectory.Path, "public.pem")
+        });
+
+        IClock clock = new SystemClock();
+        var service = new JwtTokenService(options, NullLogger<JwtTokenService>.Instance, clock);
+        var user = new User("user-1", "alice", "alice@example.com", "hash", clock.UtcNow);
+        user.AssignRole(Role.Create("role-1", DefaultRoles.Customer));
+
+        var result = await service.CreateTokenAsync(user);
+
+        result.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(result.AccessToken);
+        jwt.Issuer.Should().Be(options.Value.Issuer);
+        jwt.Audiences.Should().Contain(options.Value.Audience);
+        jwt.Claims.Should().Contain(claim => claim.Type == JwtRegisteredClaimNames.Sub && claim.Value == user.Id);
+        jwt.Claims.Should().Contain(claim => claim.Type == "role" && claim.Value == DefaultRoles.Customer);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/Services.Identity.Tests/Security/PasswordHasherServiceTests.cs
+++ b/tests/Services.Identity.Tests/Security/PasswordHasherServiceTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using MicroShop.Services.Identity.Application.Abstractions;
+using MicroShop.Services.Identity.Domain.Entities;
+using MicroShop.Services.Identity.Infrastructure.Security;
+using Xunit;
+
+namespace MicroShop.Services.Identity.Tests.Security;
+
+public class PasswordHasherServiceTests
+{
+    [Fact]
+    public void HashAndVerifyPassword_ShouldSucceed()
+    {
+        var passwordHasher = new PasswordHasher<User>();
+        var service = new PasswordHasherService(passwordHasher);
+        var user = new User("user-1", "alice", "alice@example.com", string.Empty, DateTimeOffset.UtcNow);
+        var password = "Strong!Pass123";
+
+        var hash = service.HashPassword(user, password);
+
+        hash.Should().NotBeNullOrWhiteSpace();
+
+        var result = service.VerifyHashedPassword(user, hash, password);
+
+        result.Should().Be(PasswordVerificationResult.Success);
+    }
+}


### PR DESCRIPTION
## Summary
- add Identity domain, application, infrastructure, and API projects delivering user registration, login, and management endpoints
- integrate EF Core persistence, RSA-based JWT issuance, and MassTransit-based UserRegistered events
- provide unit and integration tests alongside Docker compose wiring and a Dockerfile for the identity API

## Testing
- not run (dotnet CLI unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7de53a9fc832fbc1ae94aa01b0f73